### PR TITLE
Update EmployeeRowMapper.java

### DIFF
--- a/src/main/java/com/sample/postgress/mapper/EmployeeRowMapper.java
+++ b/src/main/java/com/sample/postgress/mapper/EmployeeRowMapper.java
@@ -15,6 +15,7 @@ public class EmployeeRowMapper implements RowMapper<Employee> {
 		emp.setEmployeeId(rs.getString("employeeId"));
 		emp.setEmployeeName(rs.getString("employeeName"));
 		emp.setEmployeeEmail(rs.getString("employeeEmail"));
+		emp.setEmployeeAddress(rs.getString("employeeAddress"));
  
         return emp;
 	}


### PR DESCRIPTION
emp.setEmployeeAddress(rs.getString("employeeAddress")); must be added in order to get the address info returned to our Get Api call. Otherwise, the address will be returned as "null"